### PR TITLE
Update to v2021a and fix license

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2020f" %}
+{% set version = "2021a" %}
 
 package:
   name: tzdata
@@ -55,7 +55,7 @@ about:
   home: https://www.iana.org/time-zones
   dev_url: https://github.com/eggert/tz
   doc_url: https://data.iana.org/time-zones/tz-link.html
-  license: LicenseRef-Public-Domain
+  license: LicenseRef-Public-Domain AND BSD-3-clause
   license_file: LICENSE
   summary: The Time Zone Database (called tz, tzdb or zoneinfo)
 


### PR DESCRIPTION
Category:  other | subcategory:   | pkg_type:  library
Popularity:  1127918 downloads -  tzdata  2021a  Provider of IANA time zone data  copy  
Version change: bump version number from 2020f to 2021a
  license was in meta.yaml: LicenseRef-Public-Domain
Upstream License: https://github.com/eggert/tz/blob/main/LICENSE
Github changelog: https://github.com/eggert/tz/blob/main/NEWS

The package tzdata is mentioned inside the packages:
linux-sysroot | phonenumbers | python | python-tzdata

Actions:
1. Update version and SHA256
2. Fix license (LicenseRef-Public-Domain AND BSD-3-clause)

Result:
- all-succeeded on concourse
