### PR TITLE
Update to v2021d

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,18 @@ test:
           -exec head -c4 {} \; -printf \\n \
           | uniq
       )"
-      test "${heads}" = TZif
+      test "${heads}" = TZif  # [not (osx-64 or osx-arm64)]
+
+    # OSX does not have the '-printf' operator.
+    - |
+      heads="$(
+        find "${PREFIX}/share/zoneinfo" -type f \
+          \! -name \*.zi \! -name \*.tab \! -name leapseconds \
+          -exec head -c4 {} \; -print0 \
+          | uniq \
+          | cut -c1-4 \
+      )"
+      test "${heads}" = TZif  # [osx-64 or osx-arm64]
 
 about:
   home: https://www.iana.org/time-zones


### PR DESCRIPTION
Bumping to latest version.
Updated the last test to make it run-able on OSX (which does not have the `-printf` operator for the `find` command).