### PR TITLE
Update from v2022a to v2022c

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,8 +62,9 @@ about:
   home: https://www.iana.org/time-zones
   dev_url: https://github.com/eggert/tz
   doc_url: https://data.iana.org/time-zones/tz-link.html
-  license: Public-Domain AND BSD-3-clause
+  license: CC-PDDC OR BSD-3-Clause
   license_file: LICENSE
+  license_url: https://github.com/eggert/tz/blob/main/LICENSE
   summary: The Time Zone Database (called tz, tzdb or zoneinfo)
 
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ test:
           \! -name \*.zi \! -name \*.tab \! -name leapseconds \
           -exec head -c4 {} \; -printf \\n \
           | uniq
-      )"
+      )"                      # [linux]
       test "${heads}" = TZif  # [linux]
 
     # OSX does not have the '-printf' operator.
@@ -47,7 +47,7 @@ test:
           -exec head -c4 {} \; -print0 \
           | uniq \
           | cut -c1-4 \
-      )"
+      )"                      # [osx-64 or osx-arm64]
       test "${heads}" = TZif  # [osx-64 or osx-arm64]
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,31 +27,6 @@ requirements:
   host:
   run:
 
-test:
-  commands:
-    # Make sure we only package timezone information files.
-    - |                                                          # [linux]
-      heads="$( \                                                # [linux]
-        find "${PREFIX}/share/zoneinfo" -type f \                # [linux]
-          \! -name \*.zi \! -name \*.tab \! -name leapseconds \  # [linux]
-          -exec head -c4 {} \; -printf \\n \                     # [linux]
-          | uniq \                                               # [linux]
-      )"                                                         # [linux]
-      test "${heads}" = TZif                                     # [linux]
-
-    # OSX does not have the '-printf' operator.
-    - |                                                           # [osx or arm64]
-      heads="$( \                                                 # [osx or arm64]
-        find "${PREFIX}/share/zoneinfo" -type f \                 # [osx or arm64]
-          \! -name \*.zi \! -name \*.tab \! -name leapseconds \   # [osx or arm64]
-          -exec head -c4 {} \; -print0 \                          # [osx or arm64]
-          | uniq \                                                # [osx or arm64]
-          | cut -c1-4 \                                           # [osx or arm64]
-      )"                                                          # [osx or arm64]
-      test "${heads}" = TZif                                      # [osx or arm64]
-      echo "This is heads: ${heads}"  # [osx-arm64]
-
-
 about:
   home: https://www.iana.org/time-zones
   dev_url: https://github.com/eggert/tz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ about:
   dev_url: https://github.com/eggert/tz
   doc_url: https://data.iana.org/time-zones/tz-link.html
   license: CC-PDDC OR BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
   license_url: https://github.com/eggert/tz/blob/main/LICENSE
   summary: The Time Zone Database (called tz, tzdb or zoneinfo)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,13 +29,6 @@ requirements:
 
 test:
   commands:
-    # Make sure we only package zoneinfo and nothing else.
-    - |
-      dirs="$(
-        find "${PREFIX}" -mindepth 1 -maxdepth 2 \
-        \! -path "${PREFIX}/share" \! -path "${PREFIX}/conda-meta*"
-      )"
-      test "${dirs}" = "${PREFIX}/share/zoneinfo"
     # Make sure we only package timezone information files.
     - |
       heads="$(
@@ -44,7 +37,7 @@ test:
           -exec head -c4 {} \; -printf \\n \
           | uniq
       )"
-      test "${heads}" = TZif  # [not (osx-64 or osx-arm64)]
+      test "${heads}" = TZif  # [linux]
 
     # OSX does not have the '-printf' operator.
     - |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2022a" %}
+{% set version = "2022c" %}
 
 package:
   name: tzdata
@@ -6,9 +6,9 @@ package:
 
 source:
   - url: https://data.iana.org/time-zones/releases/tzdata{{ version }}.tar.gz
-    sha256: ef7fffd9f4f50f4f58328b35022a32a5a056b245c5cb3d6791dddb342f871664
+    sha256: 6974f4e348bf2323274b56dff9e7500247e3159eaa4b485dfa0cd66e75c14bfe
   - url: https://data.iana.org/time-zones/releases/tzcode{{ version }}.tar.gz
-    sha256: f8575e7e33be9ee265df2081092526b81c80abac3f4a04399ae9d4d91cdadac7
+    sha256: 3e7ce1f3620cc0481907c7e074d69910793285bffe0ca331ef1a6d1ae3ea90cc
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,18 +12,18 @@ source:
 
 build:
   number: 0
+  # This package needs to be noarch because it uses POSIX system APIs.
+  # There is no Windows port available and porting to Windows is not trivial.
+  # However, the compiled package can be used on Windows.
   noarch: generic
-  # The recipe assumes building on Linux, but we don't have "skip" active since
-  # the linter will complain with "`noarch` packages can't have selectors".
-  # skip: True  # [not linux]
+  skip: True  # [win]
   ignore_run_exports:
     - libgcc-ng
 
 requirements:
   build:
     - {{ compiler('c') }}
-    - make  # [not win]
-    - m2-make  # [win]
+    - make
   host:
   run:
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,25 +30,26 @@ requirements:
 test:
   commands:
     # Make sure we only package timezone information files.
-    - |
-      heads="$(
-        find "${PREFIX}/share/zoneinfo" -type f \
-          \! -name \*.zi \! -name \*.tab \! -name leapseconds \
-          -exec head -c4 {} \; -printf \\n \
-          | uniq
-      )"                      # [linux]
-      test "${heads}" = TZif  # [linux]
+    - |                                                          # [linux]
+      heads="$( \                                                # [linux]
+        find "${PREFIX}/share/zoneinfo" -type f \                # [linux]
+          \! -name \*.zi \! -name \*.tab \! -name leapseconds \  # [linux]
+          -exec head -c4 {} \; -printf \\n \                     # [linux]
+          | uniq \                                               # [linux]
+      )"                                                         # [linux]
+      test "${heads}" = TZif                                     # [linux]
 
     # OSX does not have the '-printf' operator.
-    - |
-      heads="$(
-        find "${PREFIX}/share/zoneinfo" -type f \
-          \! -name \*.zi \! -name \*.tab \! -name leapseconds \
-          -exec head -c4 {} \; -print0 \
-          | uniq \
-          | cut -c1-4 \
-      )"                      # [osx-64 or osx-arm64]
-      test "${heads}" = TZif  # [osx-64 or osx-arm64]
+    - |                                                           # [osx or arm64]
+      heads="$( \                                                 # [osx or arm64]
+        find "${PREFIX}/share/zoneinfo" -type f \                 # [osx or arm64]
+          \! -name \*.zi \! -name \*.tab \! -name leapseconds \   # [osx or arm64]
+          -exec head -c4 {} \; -print0 \                          # [osx or arm64]
+          | uniq \                                                # [osx or arm64]
+          | cut -c1-4 \                                           # [osx or arm64]
+      )"                                                          # [osx or arm64]
+      test "${heads}" = TZif                                      # [osx or arm64]
+      echo "This is heads: ${heads}"  # [osx-arm64]
 
 
 about:

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -20,3 +20,12 @@ done
 # Make sure we only package zoneinfo and nothing else.
 dirs="$(find "${PREFIX}" -mindepth 1 -maxdepth 2 ! -path "${PREFIX}/share" ! -path "${PREFIX}/conda-meta*")"
 test "${dirs}" = "${PREFIX}/share/zoneinfo"
+
+# Make sure we only package timezone information files.
+if [ `uname` == 'Darwin' ]; then
+  # OSX does not have the '-printf' operator.
+  heads="$(find "${PREFIX}/share/zoneinfo" -type f ! -name "*.zi" ! -name "*.tab" ! -name leapseconds -exec head -c4 {} ';' -print0 | uniq | cut -c1-4)"
+else
+  heads="$(find "${PREFIX}/share/zoneinfo" -type f ! -name "*.zi" ! -name "*.tab" ! -name leapseconds -exec head -c4 {} ';' -printf \\n | uniq)"
+fi
+test "${heads}" = TZif

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -16,3 +16,7 @@ exists() {
 for i in share/zoneinfo/{zone,iso3166,zone1970}.tab share/zoneinfo/leapseconds share/zoneinfo/tzdata.zi; do
 	exists $i
 done
+
+# Make sure we only package zoneinfo and nothing else.
+dirs="$(find "${PREFIX}" -mindepth 1 -maxdepth 2 ! -path "${PREFIX}/share" ! -path "${PREFIX}/conda-meta*")"
+test "${dirs}" = "${PREFIX}/share/zoneinfo"


### PR DESCRIPTION
Addresses ticket [DSNC-5217](https://anaconda.atlassian.net/browse/DSNC-5217) and makes [DSNC-5210](https://anaconda.atlassian.net/jira/software/c/projects/DSNC/issues/DSNC-5210) obsolete.