### PR TITLE
Version 2023d

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2023c" %}
+{% set version = "2023d" %}
 
 package:
   name: tzdata
@@ -6,9 +6,9 @@ package:
 
 source:
   - url: https://data.iana.org/time-zones/releases/tzdata{{ version }}.tar.gz
-    sha256: 3f510b5d1b4ae9bb38e485aa302a776b317fb3637bdb6404c4adf7b6cadd965c
+    sha256: dbca21970b0a8b8c0ceceec1d7b91fa903be0f6eca5ae732b5329672232a08f3
   - url: https://data.iana.org/time-zones/releases/tzcode{{ version }}.tar.gz
-    sha256: 46d17f2bb19ad73290f03a203006152e0fa0d7b11e5b71467c4a823811b214e7
+    sha256: e9a5f9e118886d2de92b62bb05510a28cc6c058d791c93bd6b84d3292c3c161e
 
 build:
   number: 0


### PR DESCRIPTION
tzdata 2023d

**Destination channel:** defaults

### Links

- [PKG-3705](https://anaconda.atlassian.net/browse/PKG-3705)
- [Upstream repository](https://github.com/eggert/tz/tree/2023d)

### Explanation of changes:

- Bump version to `2023d`
- Add `abs.yaml` for 3.12 build


[PKG-3705]: https://anaconda.atlassian.net/browse/PKG-3705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ