### PR TITLE
tzdata 2024b

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,6 @@
 make -e \
   DESTDIR=./build \
   USRDIR='' \
-  POSIXRULES='' \
   install
 
 mkdir -p "${PREFIX}/share"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2024a" %}
+{% set version = "2024b" %}
 
 package:
   name: tzdata
@@ -6,9 +6,9 @@ package:
 
 source:
   - url: https://data.iana.org/time-zones/releases/tzdata{{ version }}.tar.gz
-    sha256: 0d0434459acbd2059a7a8da1f3304a84a86591f6ed69c6248fffa502b6edffe3
+    sha256: 70e754db126a8d0db3d16d6b4cb5f7ec1e04d5f261255e4558a67fe92d39e550
   - url: https://data.iana.org/time-zones/releases/tzcode{{ version }}.tar.gz
-    sha256: 80072894adff5a458f1d143e16e4ca1d8b2a122c9c5399da482cb68cba6a1ff8
+    sha256: 5e438fc449624906af16a18ff4573739f0cda9862e5ec28d3bcb19cbaed0f672
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5667](https://anaconda.atlassian.net/browse/PKG-5667) 
- [Upstream repository](https://data.iana.org/time-zones/releases/tzdata2024b.tar.gz)

### Explanation of changes:

- Remove `POSIXRULES='' \` as it seems broken. The conda-forge recipe fails in the same way https://github.com/conda-forge/tzdata-feedstock/pull/30

### Notes:

-

[PKG-5667]: https://anaconda.atlassian.net/browse/PKG-5667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ