### PR TITLE
tzdata 2025a

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,15 @@
+#!/bin/bash
+set -ex
+
+# by default the makefile does not install leap-seconds.list;
+# however, some implementations (e.g. libc++) rely on it so
+# we expand the default (TZDATA_TEXT=tzdata.zi leapseconds)
+
 make -e \
   DESTDIR=./build \
+  EXPIRES_LINE=1 \
   USRDIR='' \
+  TZDATA_TEXT='tzdata.zi leapseconds leap-seconds.list' \
   install
 
 mkdir -p "${PREFIX}/share"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2024b" %}
+{% set version = "2025b" %}
 
 package:
   name: tzdata
@@ -6,9 +6,9 @@ package:
 
 source:
   - url: https://data.iana.org/time-zones/releases/tzdata{{ version }}.tar.gz
-    sha256: 70e754db126a8d0db3d16d6b4cb5f7ec1e04d5f261255e4558a67fe92d39e550
+    sha256: 4d5fcbc72c7c450ebfe0b659bd0f1c02fbf52fd7f517a9ea13fe71c21eb5f0d0
   - url: https://data.iana.org/time-zones/releases/tzcode{{ version }}.tar.gz
-    sha256: 5e438fc449624906af16a18ff4573739f0cda9862e5ec28d3bcb19cbaed0f672
+    sha256: 119679d59f76481eb5e03d3d2a47d7870d592f3999549af189dbd31f2ebf5061
 
 build:
   number: 0
@@ -32,6 +32,31 @@ requirements:
     - make
   host:
   run:
+
+test:
+  commands:
+    - test -f "${PREFIX}/share/zoneinfo/leapseconds"
+    - test -f "${PREFIX}/share/zoneinfo/leap-seconds.list"
+    - test -f "${PREFIX}/share/zoneinfo/iso3166.tab"
+    - test -f "${PREFIX}/share/zoneinfo/zone1970.tab"
+    - test -f "${PREFIX}/share/zoneinfo/zone.tab"
+    - test -f "${PREFIX}/share/zoneinfo/tzdata.zi"
+    # Make sure we only package zoneinfo and nothing else.
+    - |
+      dirs="$(
+        find "${PREFIX}" -mindepth 1 -maxdepth 2 \
+        \! -path "${PREFIX}/share" \! -path "${PREFIX}/conda-meta*"
+      )"
+      test "${dirs}" = "${PREFIX}/share/zoneinfo"
+    # Make sure we only package timezone information files.
+    - |
+      heads="$(
+        find "${PREFIX}/share/zoneinfo" -type f \
+          \! -name \*.zi \! -name \*.tab \! -name leapseconds \! -name leap-seconds.list \
+          -exec sh -c 'head -c4 $1 && echo' sh {} \; \
+          | uniq
+      )"
+      test "${heads}" = TZif
 
 about:
   home: https://www.iana.org/time-zones

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,30 +33,7 @@ requirements:
   host:
   run:
 
-test:
-  commands:
-    - test -f "${PREFIX}/share/zoneinfo/leapseconds"
-    - test -f "${PREFIX}/share/zoneinfo/leap-seconds.list"
-    - test -f "${PREFIX}/share/zoneinfo/iso3166.tab"
-    - test -f "${PREFIX}/share/zoneinfo/zone1970.tab"
-    - test -f "${PREFIX}/share/zoneinfo/zone.tab"
-    - test -f "${PREFIX}/share/zoneinfo/tzdata.zi"
-    # Make sure we only package zoneinfo and nothing else.
-    - |
-      dirs="$(
-        find "${PREFIX}" -mindepth 1 -maxdepth 2 \
-        \! -path "${PREFIX}/share" \! -path "${PREFIX}/conda-meta*"
-      )"
-      test "${dirs}" = "${PREFIX}/share/zoneinfo"
-    # Make sure we only package timezone information files.
-    - |
-      heads="$(
-        find "${PREFIX}/share/zoneinfo" -type f \
-          \! -name \*.zi \! -name \*.tab \! -name leapseconds \! -name leap-seconds.list \
-          -exec sh -c 'head -c4 $1 && echo' sh {} \; \
-          | uniq
-      )"
-      test "${heads}" = TZif
+# Test commands are placed in run_test.sh
 
 about:
   home: https://www.iana.org/time-zones

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2025b" %}
+{% set version = "2025a" %}
 
 package:
   name: tzdata

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -22,10 +22,6 @@ dirs="$(find "${PREFIX}" -mindepth 1 -maxdepth 2 ! -path "${PREFIX}/share" ! -pa
 test "${dirs}" = "${PREFIX}/share/zoneinfo"
 
 # Make sure we only package timezone information files.
-if [ `uname` == 'Darwin' ]; then
-  # OSX does not have the '-printf' operator.
-  heads="$(find "${PREFIX}/share/zoneinfo" -type f ! -name "*.zi" ! -name "*.tab" ! -name leapseconds -exec head -c4 {} ';' -print0 | uniq | cut -c1-4)"
-else
-  heads="$(find "${PREFIX}/share/zoneinfo" -type f ! -name "*.zi" ! -name "*.tab" ! -name leapseconds -exec head -c4 {} ';' -printf \\n | uniq)"
-fi
+heads="$(find "${PREFIX}/share/zoneinfo" -type f ! -name "*.zi" ! -name "*.tab" ! -name leapseconds ! -name leap-seconds.list -exec sh -c 'head -c4 $1 && echo' sh {} \; uniq)"
+
 test "${heads}" = TZif

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -22,6 +22,10 @@ dirs="$(find "${PREFIX}" -mindepth 1 -maxdepth 2 ! -path "${PREFIX}/share" ! -pa
 test "${dirs}" = "${PREFIX}/share/zoneinfo"
 
 # Make sure we only package timezone information files.
-heads="$(find "${PREFIX}/share/zoneinfo" -type f ! -name "*.zi" ! -name "*.tab" ! -name leapseconds ! -name leap-seconds.list -exec sh -c 'head -c4 $1 && echo' sh {} \; uniq)"
-
+heads="$(
+        find "${PREFIX}/share/zoneinfo" -type f \
+          \! -name \*.zi \! -name \*.tab \! -name leapseconds \! -name leap-seconds.list \
+          -exec sh -c 'head -c4 $1 && echo' sh {} \; \
+          | uniq
+      )"
 test "${heads}" = TZif

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -13,7 +13,7 @@ exists() {
 	fi
 }
 
-for i in share/zoneinfo/{zone,iso3166,zone1970}.tab share/zoneinfo/leapseconds share/zoneinfo/tzdata.zi; do
+for i in share/zoneinfo/{zone,iso3166,zone1970}.tab share/zoneinfo/leapseconds share/zoneinfo/leap-seconds.list share/zoneinfo/tzdata.zi; do
 	exists $i
 done
 


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6801](https://anaconda.atlassian.net/browse/PKG-6801) 
- [Upstream repository](https://data.iana.org/time-zones/releases/tzdata2025a.tar.gz)

### Explanation of changes:

- Install `leap-seconds.list `(based on the conda-forge PR https://github.com/conda-forge/tzdata-feedstock/pull/29) and test it.
- Remove the `printf` command in tests.


[PKG-6801]: https://anaconda.atlassian.net/browse/PKG-6801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ