### PR TITLE
update to 2025c

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2025b" %}
+{% set version = "2025c" %}
 
 package:
   name: tzdata
@@ -6,9 +6,9 @@ package:
 
 source:
   - url: https://data.iana.org/time-zones/releases/tzdata{{ version }}.tar.gz
-    sha256: 11810413345fc7805017e27ea9fa4885fd74cd61b2911711ad038f5d28d71474
+    sha256: 4aa79e4effee53fc4029ffe5f6ebe97937282ebcdf386d5d2da91ce84142f957
   - url: https://data.iana.org/time-zones/releases/tzcode{{ version }}.tar.gz
-    sha256: 05f8fedb3525ee70d49c87d3fae78a8a0dbae4fe87aa565c65cda9948ae135ec
+    sha256: 697ebe6625444aef5080f58e49d03424bbb52e08bf483d3ddb5acf10cbd15740
 
 build:
   number: 0
@@ -17,17 +17,17 @@ build:
   # The Windows build will be skipped when built to avoid Prefect failures.
   # There is no Windows port available and porting to Windows is not trivial.
   # However, the compiled package can be used on Windows.
-  # Tzdata is utilizing system header files which is not
-  # compatible with macOS.
-  # Since we are using using a noarch build, we can
-  # simply focus linux as our main build
-
-  skip: True  # [not (linux and x86_64)]
-  ignore_run_exports:
-    - libgcc-ng
+  # Tzdata is utilizing system header files which is not compatible with macOS.
+  # However We build on osx because sysroot_linux-<arch> depends on tzdata.
+  # Since this package is data-only, we don't want any of the run-exports.
+  skip: True  # [not osx]
+  ignore_run_exports_from:
+    - {{ stdlib('c') }}
+    - {{ compiler('c') }}
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - make
   host:


### PR DESCRIPTION
tzdata 2025c

**Destination channel:** main

### Links

- https://anaconda.atlassian.net/browse/PKG-11357
Project Home URL: https://www.iana.org/time-zones
Project Dev URL: https://github.com/eggert/tz

### Explanation of changes:

- Building from osx instead of linux, because sysroot_linux-<arch> depends on tzdata.
