### PR TITLE
update to 2026c

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2026b" %}
+{% set version = "2026c" %}
 
 package:
   name: tzdata
@@ -6,9 +6,9 @@ package:
 
 source:
   - url: https://data.iana.org/time-zones/releases/tzdata{{ version }}.tar.gz
-    sha256: 114543d9f19a6bfeb5bca43686aea173d38755a3db1f2eec112647ae92c6f544
+    sha256: e4a178a4477f3d0ea77cc31828ff72aa38feff8d61aa13e7e99e142e9d902be4
   - url: https://data.iana.org/time-zones/releases/tzcode{{ version }}.tar.gz
-    sha256: 37e9ed8427f5d3521c22fc58e293cbfb043d70eedf1003870b33f363f61ca344
+    sha256: b1cffc3ace4c4c7cd0efba2f7add86ec3d0b79da48bcf03582671fd3c8feace8
 
 build:
   number: 0


### PR DESCRIPTION
tzdata 2026c

**Destination channel:** defaults

### Links
- [PKG-16271](https://anaconda.atlassian.net/browse/PKG-16271)
- [IANA release directory](https://data.iana.org/time-zones/releases/)
- [Upstream NEWS](https://github.com/eggert/tz/blob/2026c/NEWS)

### Explanation of changes:
- Updated tzdata from 2026b to 2026c.
- Updated both IANA source hashes for `tzdata2026c.tar.gz` and `tzcode2026c.tar.gz`.
- Build number remains 0 for the version bump.
- No dependency, patch, or test changes were needed.

Made with [Cursor](https://cursor.com)

[PKG-16271]: https://anaconda.atlassian.net/browse/PKG-16271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ